### PR TITLE
fix: Ajoute les permissions nécessaires pour la création de release e…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write # Autorise la création de release et le push de tags
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,8 +23,6 @@ jobs:
         run: |
           echo "Aucune préparation nécessaire. Les fichiers sont déjà dans extension/."
 
-    permissions:
-      contents: write # Autorise la création de release et le push de tags
       - name: Bump manifest version
         id: version
         run: |


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration. The change grants the workflow additional permissions to allow release creation and tag pushing.

* Workflow permissions: Added `contents: write` under `permissions` in `.github/workflows/cd.yml` to authorize release creation and tag pushes.